### PR TITLE
Widen extended commit message under "..."

### DIFF
--- a/github-wide.css
+++ b/github-wide.css
@@ -131,4 +131,9 @@ button.discussion-sidebar-toggle {
   width: 230px !important;
 }
 
+/* Commits: extended message under "..." */
+.commit-desc pre {
+  max-width: inherit;
+}
+
 }


### PR DESCRIPTION
Use all available width for extended commit message under "..." instead of GH's 770px:

![screenshot-fs8](https://cloud.githubusercontent.com/assets/1310400/7621517/184b765c-f9d0-11e4-9b18-135e79e25c34.png)

Uhmm, should I submit it to mdo/github-wide?
