### PR TITLE
fix for compatible with Octotree extension

### DIFF
--- a/github-wide.css
+++ b/github-wide.css
@@ -3,7 +3,8 @@
 @-moz-document domain("github.com") {
 
 .container {
-  width: 100% !important;
+  width: auto !important;
+  min-width: 980px !important;
   padding-left: 30px !important;
   padding-right: 30px !important;
 }


### PR DESCRIPTION
extension: https://github.com/buunguyen/octotree
Without fix page width keep 100% of window and after shift have horisontal scrolling.
