### PR TITLE
Remove max-width on inline comments

### DIFF
--- a/gist-wide.css
+++ b/gist-wide.css
@@ -1,3 +1,7 @@
+@namespace url(http://www.w3.org/1999/xhtml);
+
+@-moz-document domain("gist.github.com") {
+
 footer > .container, /* Footer */
 .header > .container, /* Site header */
 .pagehead > .container, /* All pageheads */
@@ -24,4 +28,6 @@ footer > .container, /* Footer */
 
 .edit.container {
   width: 100% !important;
+}
+
 }

--- a/github-wide.css
+++ b/github-wide.css
@@ -56,6 +56,10 @@
   width: calc(100% - 240px) !important;
 }
 
+.inline-comments .comment-holder {
+  max-width: none !important;
+}
+
 /* Fix #18 - props: @auscompgeek */
 .file-header::after {
   clear: left !important;

--- a/github-wide.css
+++ b/github-wide.css
@@ -1,3 +1,7 @@
+@namespace url(http://www.w3.org/1999/xhtml);
+
+@-moz-document domain("github.com") {
+
 .container {
   width: 100% !important;
   padding-left: 30px !important;
@@ -123,3 +127,4 @@ button.discussion-sidebar-toggle {
   max-width: none;
 }
 
+}


### PR DESCRIPTION
This removes the `max-width` on inline comments, such as those left on pull requests, so they expand to fill the available width.
