### PR TITLE
Fix Header Width

### DIFF
--- a/gist-wide.css
+++ b/gist-wide.css
@@ -4,6 +4,7 @@
 
 footer > .container, /* Footer */
 .header > .container, /* Site header */
+.header > .container-lg,
 .pagehead > .container, /* All pageheads */
 .site-container > .container, /* List view */
 .site-container + .container /* Gist view */ {

--- a/github-wide.css
+++ b/github-wide.css
@@ -2,7 +2,7 @@
 
 @-moz-document domain("github.com") {
 
-.container {
+.container, .container-lg {
   width: 100% !important;
   padding-left: 30px !important;
   padding-right: 30px !important;


### PR DESCRIPTION
GitHub recently changed its CSS for the header, using a new class `.container-lg`.  The current CSS does not support this new class, so this PR provides the necessary changes.